### PR TITLE
fix: disable create collection button when name is empty COMPASS-4589

### DIFF
--- a/src/components/create-collection-modal/create-collection-modal.jsx
+++ b/src/components/create-collection-modal/create-collection-modal.jsx
@@ -210,6 +210,7 @@ class CreateCollectionModal extends PureComponent {
             text="Cancel"
             clickHandler={this.onHide} />
           <TextButton
+            disabled={!this.props.name}
             className="btn btn-primary btn-sm"
             dataTestId="create-collection-button"
             text="Create Collection"

--- a/src/components/create-collection-modal/create-collection-modal.spec.js
+++ b/src/components/create-collection-modal/create-collection-modal.spec.js
@@ -78,8 +78,9 @@ describe('CreateCollectionModal [Component]', () => {
       expect(component.find('.btn-default').hostNodes()).to.have.text('Cancel');
     });
 
-    it('renders the create button', () => {
+    it('renders the create button enabled', () => {
       expect(component.find('.btn-primary').hostNodes()).to.have.text('Create Collection');
+      expect(component.find('.btn-primary').hostNodes()).to.not.have.attr('disabled');
     });
 
     it('renders the modal form', () => {
@@ -95,6 +96,18 @@ describe('CreateCollectionModal [Component]', () => {
         component.find('#create-collection-name').hostNodes().
           simulate('change', 'collName');
         expect(changeCollectionNameSpy.calledWith('collName')).to.equal(true);
+      });
+
+      context('when setting the collection name to empty', () => {
+        beforeEach(() => {
+          component.setProps({
+            name: ''
+          });
+        });
+
+        it('disables the create button', () => {
+          expect(component.find('.btn-primary').hostNodes()).to.have.attr('disabled');
+        });
       });
     });
 


### PR DESCRIPTION
## Description
Disables the "Create Collection" button as long as the collection name is empty.

![compass-4589](https://user-images.githubusercontent.com/4354632/110655574-7533d580-81bf-11eb-9290-6d68e889a3d8.gif)

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
