### PR TITLE
fix: ensure dialog content scrolls COMPASS-4734

### DIFF
--- a/src/components/create-collection-modal/create-collection-modal.less
+++ b/src/components/create-collection-modal/create-collection-modal.less
@@ -1,5 +1,23 @@
 .create-collection-modal {
   width: 500px;
+  max-height: ~"calc(100vh - 60px)";
+  display: flex;
+  flex-direction: row;
+
+  :global(.modal-content) {
+    flex: 1 1 auto;
+    display: flex;
+    flex-direction: column;
+  }
+
+  :global(.modal-header, .modal-footer) {
+    flex: 0 0 auto;
+  }
+
+  :global(.modal-body) {
+    flex: 0 1 auto;
+    overflow: auto;
+  }
 
   p {
     font-weight: bold;


### PR DESCRIPTION
## Description
Ensures the dialog content scrolls to prevent the dialog from outgrowing the application window.

![compass-4734](https://user-images.githubusercontent.com/4354632/112515538-a226e180-8d96-11eb-9e29-9df227d80f74.gif)

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
